### PR TITLE
Initial support for radare2/r2pipe

### DIFF
--- a/ripr/__init__.py
+++ b/ripr/__init__.py
@@ -1,25 +1,28 @@
 import sys
 if (sys.platform == 'win32'):
     sys.path.append("C:\\Python27\\lib\\site-packages\\PyQt5")
-from binaryninja import *
+try:
+    from binaryninja import *
 
-# ripr imports
-from analysis_engine import *
-from codegen import *
-from packager import *
-import gui
+    # ripr imports
+    from analysis_engine import *
+    from codegen import *
+    from packager import *
+    import gui
 
-ui = gui.riprWidget()
-def packageFunction(view, fobj):
-    engine = get_engine(view, fobj)
-    pkg = Packager(isFunc=True, address=fobj.start, engine=engine, ui=ui)
-    pkg.package_function()
+    ui = gui.riprWidget()
+    def packageFunction(view, fobj):
+        engine = get_engine(view, fobj)
+        pkg = Packager(isFunc=True, address=fobj.start, engine=engine, ui=ui)
+        pkg.package_function()
 
-def packageRegion(view, start, length):
-    print "[ripr] Packaging 0x%x - 0x%x" % (start, start+length)
-    engine = get_engine(view)
-    pkg = Packager(isFunc=False, address=start, engine=engine, length=length, ui=ui)
-    pkg.package_region()
+    def packageRegion(view, start, length):
+        print "[ripr] Packaging 0x%x - 0x%x" % (start, start+length)
+        engine = get_engine(view)
+        pkg = Packager(isFunc=False, address=start, engine=engine, length=length, ui=ui)
+        pkg.package_region()
 
 
-PluginCommand.register_for_function("[ripr] Package Function", "Package Function within Unicorn", packageFunction)
+    PluginCommand.register_for_function("[ripr] Package Function", "Package Function within Unicorn", packageFunction)
+except ImportError:
+    pass

--- a/ripr/analysis_engine.py
+++ b/ripr/analysis_engine.py
@@ -9,9 +9,16 @@ try:
 except:
     print "[!!] Not running in Binary Ninja"
 
+try:
+    import r2pipe
+except:
+    print "[!!] Not running in Radare2"
+
+import json
+import re
 import sys
-import gui
 import codegen
+from binascii import unhexlify
 
 def get_engine(*args):
     '''
@@ -20,6 +27,11 @@ def get_engine(*args):
     print args
     if ("binaryninja" in sys.modules.keys()):
         return bn_engine(args[0])
+
+    if ("r2pipe" in sys.modules.keys()):
+        return radare2_engine(r2pipe.open())
+
+    raise ValueError, "No analysis engine found!"
     
 
 
@@ -62,7 +74,7 @@ class aengine(object):
         '''
         pass
 
-    def get_nop_opcode(self, arch):
+    def get_nop_opcode(self):
         '''
             Function should return a string corresponding to a NOP on the specified
             architecture.
@@ -82,6 +94,48 @@ class aengine(object):
             Function should return a string containing
             $len bytes at $address.
         '''
+        pass
+
+    def get_imports(self):
+        raise NotImplementedError
+
+    def get_instruction_length(self, address):
+        raise NotImplementedError
+
+    def get_data_symbols(self):
+        raise NotImplementedError
+
+    def get_strings(self):
+        raise NotImplementedError
+
+    def get_refs_to(self, address):
+        raise NotImplementedError
+
+    def function_contains_addr(self, func_addr, testAddr):
+        raise NotImplementedError
+
+    def get_page_size(self):
+        raise NotImplementedError
+
+    def generate_invalid_access(self, address, arch, size=None):
+        raise NotImplementedError
+
+    def branches_from_func(self, address, callCallback, branchCallback):
+        raise NotImplementedError
+
+    def scan_potential_pointers(self, func_addr):
+        raise NotImplementedError
+
+    def is_plausible_pointer(self, candidate_ptr):
+        raise NotImplementedError
+
+    def highlight_instr(self, func_addr, instrAddr, color):
+        pass
+
+    def add_comment(self, func_addr, instrAddr, comment):
+        pass
+
+    def display_info(self, info1, info2):
         pass
 
 class bn_engine(aengine):
@@ -177,3 +231,275 @@ class bn_engine(aengine):
                 return opcodes + nop * (size - len(opcodes))
             else:
                 return self.bv.arch.assemble('mov al, [%s]' % address)[0]
+
+    def get_imports(self):
+        return {self.bv.symbols[sym].address : self.bv.symbols[sym] for sym in self.bv.symbols if self.bv.symbols[sym].type == SymbolType.ImportedFunctionSymbol}
+
+
+    def get_instruction_length(self, address):
+        return self.bv.get_instruction_length(address)
+
+    def branches_from_func(self, address, callCallback, branchCallback):
+        fobj = self.bv.get_function_at(address)
+        for block in fobj.low_level_il:
+            for il_inst in block:
+                print il_inst
+                if (il_inst.operation == LowLevelILOperation.LLIL_CALL):
+                    #core.LLIL_JUMP, core.LLIL_JUMP_TO, core.LLIL_GOTO]):
+                    callCallback(il_inst.dest.value, il_inst.address)
+                # Check Jump targets
+                elif (il_inst.operation in [LowLevelILOperation.LLIL_JUMP, LowLevelILOperation.LLIL_JUMP_TO, LowLevelILOperation.LLIL_GOTO]):
+                    branchCallback(il_inst.dest.value, il_inst.address)
+                else:
+                    pass
+
+    def get_data_symbols(self):
+        for sym in self.bv.symbols:
+            if self.bv.symbols[sym].type == 'DataSymbol':
+                yield sym.address()
+
+    def get_strings(self):
+        for st in self.bv.strings:
+            yield (st.start, st.length)
+
+    def get_refs_to(self, address):
+        fobj = self.bv.get_function_at(address)
+        for ref in self.bv.get_code_refs(symbols[sym].address):
+            yield ref.address
+
+    def function_contains_addr(self, func_addr, testAddr):
+        fobj = self.bv.get_function_at(address)
+        return (fobj.get_basic_block_at(testAddr) != None)
+
+
+    def scan_potential_pointers(self, func_addr):
+        # Iterate over all instructions in each basic block
+        fobj = self.bv.get_function_at(func_addr)
+        for block in fobj.low_level_il:
+            for il_inst in block:
+                constants = fobj.get_constants_referenced_by(il_inst.address)
+                # Check if constant is a likely pointer
+                for const in constants:
+                    yield const.value, il_inst.address
+                # Memory things
+                if (il_inst.operation in [LowLevelILOperation.LLIL_LOAD, LowLevelILOperation.LLIL_STORE, LowLevelILOperation.LLIL_CONST, LowLevelILOperation.LLIL_UNIMPL_MEM, LowLevelILOperation.LLIL_SET_REG]):
+                    print "[ripr] Found memory based instruction"
+                    print "%s ::> %s" % (il_inst, il_inst.operation)
+                    print il_inst.operands
+                    if (il_inst.operation == LowLevelILOperation.LLIL_STORE):
+                        yield il_inst
+                        try:
+
+                            yield self.bv.is_valid_offset(il_inst.operands[0].value), il_inst.address
+                        except:
+                            pass
+
+
+    def is_plausible_pointer(self, candidate_ptr):
+        return self.bv.is_valid_offset(candidate_ptr)
+
+
+    def find_section(self, addr):
+        '''
+            Function should find what segment/section $addr is in and return a tuple
+            (StartAddress, Endaddress, Segment Name)
+            Error: Return -1
+        '''
+        res = []
+        for sec in self.bv.get_sections_at(addr):
+            return ((sec.start, sec.start + sec.length, sec.name))
+        return -1
+
+
+    def highlight_instr(self, func_addr, instrAddr, color):
+        fobj = self.bv.get_function_at(func_addr)
+        if color == "red":
+            bn_color = HighlightStandardColor.RedHighlightColor
+        elif color == "blue":
+            bn_color = HighlightStandardColor.BlueHighlightColor
+        elif color == "yellow":
+            bn_color = HighlightStandardColor.YellowHighlightColor
+        else:
+            raise ValueError, "Unsupported color"
+        fobj.set_user_instr_highlight(instrAddr, bn_color)
+
+    def add_comment(self, func_addr, instrAddr, comment):
+        fobj = self.bv.get_function_at(func_addr)
+        fobj.set_comment(instrAddr, "[ripr] " + comment)
+
+    def display_info(self, info1, info2):
+        self.bv.show_plain_text_report(info1, info2)
+
+class radare2_engine(aengine):
+    def get_data_symbols(self):
+        for symbol in self.r2.cmdj("isj"):
+            if symbol['type'] == "OBJECT":
+                yield symbol['vaddr']
+
+
+    def get_strings(self):
+         for symbol in self.r2.cmdj("izj"):
+            yield symbol['vaddr'], symbol['size']
+
+    def get_refs_to(self, address):
+        res = self.r2.cmd("axtj {}".format(hex(address)))
+        if res is None or len(res) == 0:
+            return
+        res = json.loads(res)
+        for ref in res:
+            yield ref['from']
+
+    def function_contains_addr(self, func_addr, testAddr):
+        func = self.r2.cmdj("afij @{}".format(hex(func_addr)))
+        func = func[0]
+        return testAddr >= func['offset'] and testAddr < func['offset']+func['size']
+
+    def __init__(self, r2):
+        self.r2 = r2
+        aengine.__init__(self)
+
+    def read_bytes(self, address, size):
+        bytes = []
+        hexdump = self.r2.cmd("pc {} @ {}".format(size,hex(address)))
+        for line in hexdump.split("\n"):
+            if "0x" in line:
+                for byte in line.split(","):
+                    byte = byte.strip()
+                    if len(byte) == 0:
+                        continue
+                    byte = int(byte, 16)
+                    bytes.append(chr(byte))
+        assert len(bytes) == size
+        return ''.join(bytes)
+
+    def get_arch(self):
+        info = self.r2.cmdj("ifj")
+        arch = info['bin']['arch']
+        bits = info['bin']['bits']
+        if arch == "x86" and bits == 32:
+            return 'x86'
+        elif arch == "x86" and bits == 64:
+            return 'x64'
+        else:
+            raise NotImplementedError, "Only tested witn x86 & x86_64"
+
+    def get_function_bytes(self, address=None, name=None):
+        if (address != None):
+            funcInfo = self.r2.cmd("afij {}".format(hex(address)))
+        elif (name != None):
+            print "[ripr] TODO"
+            return
+        else:
+            print "[ripr] No arguments supplied to get_function_bytes"
+            return None
+
+        if funcInfo.strip() == "":
+            raise ValueError, "Function not found at {}".format(address)
+        funcInfo = json.loads(funcInfo, strict=False)
+
+        if len(funcInfo) == 0:
+            raise ValueError, "Function not found at {}".format(address)
+        print funcInfo
+        offset = funcInfo[0]["offset"]
+        size = funcInfo[0]["size"]
+        bytes = self.read_bytes(offset, size)
+        retdir = {offset: codegen.codeSlice(bytes, offset)}
+        return retdir
+
+    def get_page_bytes(self, address):
+        # Should get this dynamically if possible based on arch/mode/etc
+        pagesize = self.get_page_size()
+        pageaddr = (address & ~(pagesize - 1))
+        return self.read_bytes(pageaddr, pagesize)
+
+    def get_page_size(self):
+        return 4096
+
+    def get_region_bytes(self, start, end):
+        return (start, self.read_bytes(start, end-start))
+
+    def get_nop_opcode(self):
+        return self.r2.cmd("pa nop").decode('hex')
+
+    def generate_invalid_access(self, address, arch, size=None):
+        '''
+            Generates an invalid memory access for use in function hooking.
+            pad to size if applicable
+        '''
+        # TODO: Radare2 seems to assemble this to a rip-relative access?
+        if arch in ['x86', 'x64']:
+            if (size):
+                opcodes = self.r2.cmd('pa mov al, [%s]' % address).decode('hex')
+                nop = self.get_nop_opcode()
+                if len(opcodes) >= size:
+                    return opcodes
+                return opcodes + nop * (size - len(opcodes))
+            else:
+                return self.r2.cmd('pa mov al, [%s]' % address).decode('hex')
+
+    def get_imports(self):
+        # Iterate through symbols and grab everything that starts with 'sym.'
+        res = {}
+        for sym in self.r2.cmdj("isj"):
+            if sym['name'].startswith("imp."):
+                res[sym['vaddr']] = sym['name'][4:]
+        return res
+
+    def branches_from_func(self, address, callCallback, branchCallback):
+        func = self.r2.cmdj("pdfj @ {}".format(hex(address)))
+        instructions = func['ops']
+        for instr in instructions:
+            if instr['type'] == 'call':
+                callCallback(instr['jump'], instr['offset'])
+            elif instr['type'] == 'cjmp' or instr['type'] == 'jmp':
+                branchCallback(instr['jump'], instr['offset'])
+            #TODO: Any other?
+
+    def scan_potential_pointers(self, func_addr):
+        # Leverage Radare2 automatic pointer detection
+        func = self.r2.cmdj("pdfj @ {}".format(hex(func_addr)))
+        res = []
+        for line in func['ops']:
+            if 'ptr' in line:
+                yield line['ptr'], line['offset']
+
+    def is_plausible_pointer(self, candidate_ptr):
+        # A manual scan of all sections
+        for section in self.r2.cmdj("Sj"):
+            if candidate_ptr >= section['vaddr'] and \
+                candidate_ptr < section['vaddr'] + section['vsize']:
+                return True
+        return False
+
+    def find_section(self, addr):
+        '''
+            Function should find what segment/section $addr is in and return a tuple
+            (StartAddress, Endaddress, Segment Name)
+            Error: Return -1
+        '''
+        # A manual scan of all sections
+        res = []
+        for section in self.r2.cmdj("Sj"):
+            if addr >= section['vaddr'] and \
+                addr < section['vaddr'] + section['vsize']:
+                return (
+                    section['vaddr'],
+                    section['vaddr'] + section['vsize'],
+                    section['name'])
+
+        return -1
+
+    def get_instruction_length(self, address):
+        return self.r2.cmdj("pdj 1 @{}".format(hex(address)))[0]['size']
+
+    def highlight_instr(self, func_addr, instrAddr, color):
+        # No highlighting yet
+        pass
+
+    def add_comment(self, func_addr, instrAddr, comment):
+        if not re.compile("^[a-z0-9 !\\-\\_]+$", re.IGNORECASE).match(comment):
+            # Don't send arbitrary contents to radare pipe
+            print "Ignoring malformed comment: {}".format(comment)
+        else:
+            self.r2.cmd("CC [ripr] {} @{}".format(comment, hex(instrAddr)))
+

--- a/ripr/cli_ui.py
+++ b/ripr/cli_ui.py
@@ -1,0 +1,30 @@
+
+# Instead of GUI, just prompt on the command line
+class cli_ui:
+    def yes_no_box(self, question):
+        while True:
+            response = raw_input("{} (Y/N)".format(question))
+            if len(response) < 1 or response[0] not in ['y','n','N','Y']:
+                continue
+
+            if response[0].lower() == 'y':
+                return True
+            else:
+                return False
+
+    def update_table(self, newTable):
+        #TODO: Not showing a table for now
+        pass
+
+    def text_input_box(self, promptText):
+        return raw_input(promptText + "? ").strip()
+
+    def impCallsOptions(self):
+        options = ["nop", "hook", "cancel"]
+
+        print "Code contains calls to imported functions. How should this be handled?",
+        while True:
+            selection = raw_input("({})?".format(", ".join(options))).strip()
+            if selection in options:
+                return selection
+

--- a/ripr/codegen.py
+++ b/ripr/codegen.py
@@ -16,7 +16,6 @@ except:
 
 # ripr imports
 import analysis_engine as ae
-import gui
 import dependency as dep
 
 
@@ -342,10 +341,10 @@ class genwrapper(object):
         build_funcs = []
         # Get a list of names for hook functions
         for impCall in self.impCallTargets:
-            if impCall.symbol.name not in build_funcs:
-                build_funcs.append(impCall.symbol.name)
+            if str(impCall.symbol) not in build_funcs:
+                build_funcs.append(str(impCall.symbol))
             
-            out[impCall.address + impCall.inst_len] = "hook_%s" % impCall.symbol.name
+            out[impCall.address + impCall.inst_len] = "hook_%s" % str(impCall.symbol)
 
         # Generate stubs for the hooked functions
         for func in build_funcs:

--- a/ripr/packager.py
+++ b/ripr/packager.py
@@ -1,6 +1,5 @@
 from codegen import *
 import analysis_engine as ae
-import gui
 import dependency as dep
 
 ### Global for listing all chunks of code for which we have tried to create a python wrapper.
@@ -86,7 +85,7 @@ class Packager(object):
 
         # Generate what we currently have and show the results
         self.codeobj.generate_class()
-        self.engine.bv.show_plain_text_report("Generated Code: %s" % self.codeobj.name, self.codeobj.final)
+        self.engine.display_info("Generated Code: %s" % self.codeobj.name, self.codeobj.final)
 
     def package_region(self):
         '''
@@ -171,11 +170,11 @@ class Packager(object):
         pagesize = self.engine.get_page_size()
         secs = []
         for ref in dataRefs: 
-            sections = self.engine.bv.get_sections_at(ref.address)
+            sections = [self.engine.find_section(ref.address)]
             secs += sections
-        for sec in secs:
-            self.codeobj.add_data(self.engine.read_bytes(sec.start, sec.length), sec.start)
-            self.codeobj.add_mmap(sec.start)
+        for sec_start, sec_end, sec_name in secs:
+            self.codeobj.add_data(self.engine.read_bytes(sec_start, sec_end - sec_start), sec_start)
+            self.codeobj.add_mmap(sec_start)
 
     def map_minimal_data(self, dataRefs):
         '''

--- a/ripr/r2pipe_run.py
+++ b/ripr/r2pipe_run.py
@@ -1,0 +1,17 @@
+import sys
+
+# ripr imports
+from analysis_engine import *
+from codegen import *
+from packager import *
+import cli_ui
+
+def packageFunction(addr):
+    print "[ripr] Packaging function {}".format(hex(addr))
+    engine = get_engine(addr)
+    ui = cli_ui.cli_ui()
+    pkg = Packager(isFunc=True, address=addr, engine=engine, ui=ui)
+    pkg.package_function()
+
+addr = int(sys.argv[1], 16)
+packageFunction(addr)


### PR DESCRIPTION
Hi, I patched the ripr source code to work with the open source Radare2 tool via the r2pipe interface, so that ripr doesn't require Binary Ninja. Ripr can be used by first starting radare2 from the ripr directory, performing analysis of the binary and then running `#!pipe python ./r2pipe_run.py <addr>` where `addr` is the address of the function being extracted.

A bunch of refactoring was necessary (esp. for the `dependency.py`) to make the code independent of the Binary Ninja API. I moved a bunch of Binary Ninja logic to the BN analysis engine interface and made some interfaces pass the function address instead of a Binary Ninja function object. It is very possible I might've broken some of the Binary Ninja interaction in the course of this refactoring, as I don't have a copy of Binary Ninja to confirm this still works with it. Would you mind testing with Binary Ninja to make sure it still works? Feel free to suggest style/API changes as well.

Here's an example transcript of how it looks like when used from radare:

```
ripr $ r2 /tmp/example3 
 -- Remember that word: C H A I R
[0x004007f0]> s sym.algo
[0x00400908]> aaaa
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze len bytes of instructions for references (aar)
[x] Analyze function calls (aac)
[x] Emulate code to find computed references (aae)
[x] Analyze consecutive function (aat)
[x] Type matching analysis for all functions (afta))unc.* functions (aan)
[x] Type matching analysis for all functions (afta)
[0x00400908]> #!pipe python ./r2pipe_run.py `s`
[!!] Not running in Binary Ninja
[!] Not running in IDA
[+] Not running in BinaryNinja
[ripr] Packaging function 0x400908
(4196616,)
Enter Class Name? asdf
Resolving Dependencies for 400908
[ripr] Inside branchScan
[ripr] JUMP TARGET: 4196668
[ripr] Found LLIL CALL instruction
[ripr] IL_INST Dest:
[ripr] JUMP TARGET: 4196641
[ripr] Inside dataScan
Target code may depend on outside code, attempt to map automatically? (Y/N)Y
[ripr] Performing analysis on code dependencies...
Found CodeRef: 4196582::call
Resolving Dependencies for 4008e6
[ripr] Inside branchScan
[ripr] Found imported Call target...
[ripr] Inside dataScan
Found Potential Pointer: 4196977
[ripr] Selection includes calls to imported Functions!
Code contains calls to imported functions. How should this be handled? (nop, hook, cancel)?hook
[ripr] Found these potential Data References
Data Referenced: 0x400a71
Use Section-Marking Mode for data dependencies (default; yes) (Y/N)yes
Mapping Sections
[(4196960, 4196981, u'.rodata')]
[{4196616: <codegen.codeSlice object at 0x7fbcc90c3550>}, {4196582: <codegen.codeSlice object at 0x7fbcc90c3850>}]
from unicorn import *
from unicorn.x86_const import *

import struct
class asdf(object):
    def __init__(self):
        self.mu = Uc(UC_ARCH_X86, UC_MODE_64)
        self.code_0 = '554889e54883ec10897dfcbf710a4000e885feffff8b45fc0faf45fc0faf45fcc9c3'.decode('hex') 
        self.code_1 = '554889e54883ec20897decc745fc00000000c745f8000000008b45f83b45ec7d138b45f889c7e8b3ffffff0145fc8345f801ebe58b45fcc9c3'.decode('hex') 

        self.data_0 = '010002000000000000000000000000000068692100'.decode('hex') 

        self.mu.mem_map(0x400000,0x200000)
        self.mu.mem_map(0x7ffff000,0x200000)

        self.mu.mem_write(0x400a60, self.data_0)
        self.mu.mem_write(0x4008e6, self.code_0)
        self.mu.mem_write(0x400908, self.code_1)

        self.hookdict = {4196603: 'hook_puts'}
    def hook_puts(self):
        pass
    def _start_unicorn(self, startaddr):
        try:
            self.mu.emu_start(startaddr, 0)
        except Exception as e:
            if self.mu.reg_read(UC_X86_REG_RIP) == 1:
                return
            retAddr = struct.unpack("<q", self.mu.mem_read(self.mu.reg_read(UC_X86_REG_RSP), 8))[0]
            if retAddr in self.hookdict.keys():
                getattr(self, self.hookdict[retAddr])()
                self.mu.reg_write(UC_X86_REG_RSP, self.mu.reg_read(UC_X86_REG_RSP) + 8)
                self._start_unicorn(retAddr)
            else:
                raise e
    def run(self):
        self.mu.reg_write(UC_X86_REG_RSP, 0x7fffffff)
        self.mu.mem_write(0x7fffffff, '\x01\x00\x00\x00')
        self._start_unicorn(0x400908)
        return self.mu.reg_read(UC_X86_REG_RAX)


```
Legal boilerplate: "I am providing code in this repository to you under an open source license. Because this is my personal repository, the license you receive to my code is from me and not from my employer."
